### PR TITLE
retrieve rows through a method

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -67,11 +67,12 @@ trait Sushi
 
     public function migrate()
     {
-        $rows = $this->rows;
-        $firstRow = $rows[0];
-        $tableName = $this->getTable();
+        $rows = $this->getRows();
 
         throw_unless($rows, new \Exception('Sushi: $rows property not found on model: '.get_class($this)));
+
+        $firstRow = $rows[0];
+        $tableName = $this->getTable();
 
         static::resolveConnection()->getSchemaBuilder()->create($tableName, function ($table) use ($firstRow) {
             foreach ($firstRow as $column => $value) {
@@ -87,5 +88,10 @@ trait Sushi
         });
 
         static::insert($rows);
+    }
+
+    protected function getRows()
+    {
+        return $this->rows;
     }
 }


### PR DESCRIPTION
Means you can use a method to return rows which makes it possible to use files like https://github.com/mledoze/countries/blob/master/dist/countries.json.

After this we could take this example https://github.com/calebporzio/sushi/blob/master/examples/CountryExample.php and use it like this.

```php
<?php

class CountryExample extends Model
{
	use \Sushi\Sushi;

    protected function getRows()
    {
		// Apply some transformation to normalize the data and filter out useless things
		return json_decode(file_get_contents('vendor/mledoze/countries/dist/countries.json'), true);
    }
}
```

Also added a `tests/cache` directory as tests were failing without it and moved up the `throw_unless` as the line after `$rows` is assigned already tries to access an index without checking if `$rows` is empty.