### PR TITLE
[Idea/Discussion] refactor the sushi trait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,6 @@
         {
             "name": "Caleb Porzio",
             "email": "calebporzio@gmail.com"
-        },
-        {
-            "name": "Tom Witkowski",
-            "email": "dev.gummibeer@gmail.com",
-            "homepage": "https://gummibeer.de",
-            "role": "Developer"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -6,16 +6,24 @@
         {
             "name": "Caleb Porzio",
             "email": "calebporzio@gmail.com"
+        },
+        {
+            "name": "Tom Witkowski",
+            "email": "dev.gummibeer@gmail.com",
+            "homepage": "https://gummibeer.de",
+            "role": "Developer"
         }
     ],
     "require": {
-        "illuminate/database": "~5.8.0|^6.0.0",
-        "illuminate/support": "~5.8.0|^6.0.0",
-        "illuminate/filesystem": "~5.8.0|^6.0.0"
+        "php": "^7.4",
+        "illuminate/database": "~5.8.0 || ^6.0.0",
+        "illuminate/filesystem": "~5.8.0 || ^6.0.0",
+        "illuminate/support": "~5.8.0 || ^6.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
-        "orchestra/testbench": "^4.5"
+        "fzaninotto/faker": "^1.9",
+        "orchestra/testbench": "^4.5",
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -73,7 +73,7 @@ trait Sushi
             return;
         }
 
-        foreach (Arr::except($row, ['id', 'created_at', 'updated_at']) as $column => $value) {
+        foreach (Arr::except($row, [$model->getKeyName(), 'created_at', 'updated_at']) as $column => $value) {
             if (is_int($value)) {
                 $type = 'integer';
             } elseif (is_float($value)) {

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -91,7 +91,7 @@ class SushiTest extends TestCase
     /** @test */
     public function it_inserts_all_rows()
     {
-        $this->assertEquals(101, Maki::count());
+        $this->assertSame(101, Maki::count());
     }
 
     /** @test */


### PR DESCRIPTION
I was in the need to adjust several things but everything is based on this idea. So I wanted to open this PR and show my idea(s) and discuss the changes if they are wanted in this repo or not.

* use  `getRows()` instead of simple rows property
* use `LazyCollection` instead of simple array
* add some more auto-detected column types
* allow to tap the `Blueprint` to adjust migration
* use only `:memory:` sqlite to simplify everything and prevent read-write difference between DB and array
* add some more unittests

My usecase is to read files from a flysystem disk, that's why I prefer the lazy collection.