### PR TITLE
Fix error 'Trying to access array offset on value of type null'

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -67,11 +67,11 @@ trait Sushi
 
     public function migrate()
     {
+        throw_unless(is_array($this->rows), new \Exception('Sushi: $rows property not found on model: '.get_class($this)));
+
         $rows = $this->rows;
         $firstRow = $rows[0];
         $tableName = $this->getTable();
-
-        throw_unless($rows, new \Exception('Sushi: $rows property not found on model: '.get_class($this)));
 
         static::resolveConnection()->getSchemaBuilder()->create($tableName, function ($table) use ($firstRow) {
             foreach ($firstRow as $column => $value) {


### PR DESCRIPTION
When running `phpunit` on PHP 7.4.2 homebrew OSX I got the error:

> 1) Tests\SushiTest::not_adding_rows_property_throws_an_error
Failed asserting that exception message 'Trying to access array offset on value of type null' contains 'Sushi: $rows property not found on model: Tests\Bar'.

This comes from referencing an array that doesn't exist (and grabbing its first value) here:
https://github.com/calebporzio/sushi/blob/c42bd67209029e2eaf6f0950cddf696d352b476e/src/Sushi.php#L70-L71

before checking if it's empty here:
https://github.com/calebporzio/sushi/blob/c42bd67209029e2eaf6f0950cddf696d352b476e/src/Sushi.php#L74

Your code also errors if they have the array but it's empty which I think is unintended?

This PR removes the error allowing the test to pass successfully.