### PR TITLE
Don't assume ID column is always an integer

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -75,12 +75,12 @@ trait Sushi
 
         static::resolveConnection()->getSchemaBuilder()->create($tableName, function ($table) use ($firstRow) {
             foreach ($firstRow as $column => $value) {
-                if ($column === 'id') {
+                $type = is_numeric($value) ? 'integer' : 'string';
+
+                if ($column === 'id' && $type == 'integer') {
                     $table->increments('id');
                     continue;
                 }
-
-                $type = is_numeric($value) ? 'integer' : 'string';
 
                 $table->{$type}($column);
             }


### PR DESCRIPTION
ID columns aren't always integers. For example if I'm retrieving data from the MailChimp API, each list's ID column looks something like `2f481d67b1`.

This PR simply checks for the integer type before calling ```increments()```.

ID columns are always unique though - so perhaps we want to make it unique if we're not incrementing. Thoughts?