### PR TITLE
Enable StyleCI check.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,5 @@
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.styleci.yml export-ignore
+phpunit.xml

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,3 @@
+preset: laravel
+
+linting: true


### PR DESCRIPTION
Enable StyleCI check. This repo is public so it's on a free tier. This repo needs to be enabled at https://styleci.io

---

Note: also adds `phpunit.xml` to export-ignore