### PR TITLE
Allow for a configurable cache prefix

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -17,7 +17,7 @@ trait Sushi
     public static function bootSushi()
     {
         $instance = (new static);
-        $cacheFileName = 'sushi-'.Str::kebab(str_replace('\\', '', static::class)).'.sqlite';
+        $cacheFileName = config('sushi.cache-prefix', 'sushi').'-'.Str::kebab(str_replace('\\', '', static::class)).'.sqlite';
         $cacheDirectory = realpath(config('sushi.cache-path', storage_path('framework/cache')));
         $cachePath = $cacheDirectory.'/'.$cacheFileName;
         $modelPath = (new \ReflectionClass(static::class))->getFileName();


### PR DESCRIPTION
Slight tweak to allow for a cache prefix set by a config file.  
:card_index:

Next step could be to create a config file that can be vendor:publish -ed :package: