### PR TITLE
Auto add primary key if needed

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -74,11 +74,15 @@ trait Sushi
         $tableName = $this->getTable();
 
         static::resolveConnection()->getSchemaBuilder()->create($tableName, function ($table) use ($firstRow) {
+            if ($this->incrementing && ! in_array($this->primaryKey, $firstRow)) {
+                $table->increments($this->primaryKey);
+            }
+
             foreach ($firstRow as $column => $value) {
                 $type = is_numeric($value) ? 'integer' : 'string';
 
-                if ($column === 'id' && $type == 'integer') {
-                    $table->increments('id');
+                if ($column === $this->primaryKey && $type == 'integer') {
+                    $table->increments($this->primaryKey);
                     continue;
                 }
 

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -76,6 +76,13 @@ class SushiTest extends TestCase
     {
         $this->markTestSkipped('I can\' find a good way to test this right now');
     }
+
+    /** @test */
+    function adds_primary_key_if_needed()
+    {
+        $this->assertEquals(1, Foo::find(1)->getKey());
+    }
+
 }
 
 class Foo extends Model


### PR DESCRIPTION
This will automatically add primary keys if they're not specified and the model's incrementing variable is set to true.  Will use the model's primaryKey value for the column name.  This also removes the hardcoded "id" check and now checks against the model's primaryKey instead.