### PR TITLE
Extract exceptions to own directory

### DIFF
--- a/src/Exceptions/MigrationException.php
+++ b/src/Exceptions/MigrationException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Sushi\Exceptions;
+
+class MigrationException extends \Exception
+{
+
+    public static function modelRowsNotFound($class)
+    {
+        return new static('Sushi: $rows property not found on model: ' . $class);
+    }
+}

--- a/src/Exceptions/MigrationException.php
+++ b/src/Exceptions/MigrationException.php
@@ -4,7 +4,6 @@ namespace Sushi\Exceptions;
 
 class MigrationException extends \Exception
 {
-
     public static function modelRowsNotFound($class)
     {
         return new static('Sushi: $rows property not found on model: ' . $class);

--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -68,7 +68,7 @@ trait Sushi
 
     public function migrate()
     {
-        throw_unless(is_array($this->rows),MigrationException::modelRowsNotFound(get_class($this)));
+        throw_unless(is_array($this->rows), MigrationException::modelRowsNotFound(get_class($this)));
 
         $rows = $this->rows;
         $firstRow = $rows[0];

--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -4,6 +4,7 @@ namespace Sushi;
 
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Support\Str;
+use Sushi\Exceptions\MigrationException;
 
 trait Sushi
 {
@@ -67,7 +68,7 @@ trait Sushi
 
     public function migrate()
     {
-        throw_unless(is_array($this->rows), new \Exception('Sushi: $rows property not found on model: '.get_class($this)));
+        throw_unless(is_array($this->rows),MigrationException::modelRowsNotFound(get_class($this)));
 
         $rows = $this->rows;
         $firstRow = $rows[0];

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -5,6 +5,7 @@ namespace Tests;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\File;
 use Orchestra\Testbench\TestCase;
+use Sushi\Exceptions\MigrationException;
 
 class SushiTest extends TestCase
 {
@@ -40,6 +41,7 @@ class SushiTest extends TestCase
     function not_adding_rows_property_throws_an_error()
     {
         $this->expectExceptionMessage('Sushi: $rows property not found on model: Tests\Bar');
+        $this->expectException(MigrationException::class);
 
         Bar::count();
     }


### PR DESCRIPTION
Extract exceptions into their own directory, allows for expansion in the future and cleans up from throwing a generic exception as is the case currently. Tests have also been updated to include the newest additions.