### PR TITLE
Fix failing test on windows due to path separator

### DIFF
--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -63,7 +63,7 @@ class SushiTest extends TestCase
         $this->assertTrue(file_exists($this->cachePath));
         $this->assertStringContainsString(
             'sushi/tests/cache/sushi-tests-foo.sqlite',
-            (new Foo)->getConnection()->getDatabaseName()
+            str_replace('\\', '/', (new Foo())->getConnection()->getDatabaseName())
         );
     }
 


### PR DESCRIPTION
This test `caches_sqlite_file_if_storage_cache_folder_is_available` fails on windows due to `\` instead of `/`
This PR solves that