### PR TITLE
Allow testing with fake data Sushi::test()

### DIFF
--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -91,6 +91,45 @@ class SushiTest extends TestCase
         $this->assertEquals(1, Foo::find(1)->getKey());
     }
 
+    /** @test */
+    public function can_be_used_in_a_test_environment()
+    {
+        $this->assertEquals([
+            ['id' => 1, 'foo' => 'bar', 'bob' => 'lob'],
+            ['id' => 2, 'foo' => 'bar', 'bob' => 'lob'],
+            ['id' => 3, 'foo' => 'baz', 'bob' => 'law'],
+        ], Foo::all()->toArray());
+
+        Foo::test([
+            ['name' => 'foo'],
+            ['name' => 'bar'],
+        ]);
+
+        $this->assertEquals([
+            ['id' => 1, 'name' => 'foo'],
+            ['id' => 2, 'name' => 'bar'],
+        ], Foo::all()->toArray());
+
+        Foo::test([
+            ['name' => 'baz'],
+            ['name' => 'naz'],
+        ]);
+
+        Baz::test([
+            ['name' => 'wut'],
+            ['name' => 'tit'],
+        ]);
+
+        $this->assertEquals([
+            ['id' => 1, 'name' => 'baz'],
+            ['id' => 2, 'name' => 'naz'],
+        ], Foo::all()->toArray());
+
+        $this->assertEquals([
+            ['id' => 1, 'name' => 'wut'],
+            ['id' => 2, 'name' => 'tit'],
+        ], Baz::all()->toArray());
+    }
 }
 
 class Foo extends Model
@@ -107,6 +146,7 @@ class Foo extends Model
     {
         static::setSushiConnection(null);
         static::clearBootedModels();
+        static::$testRows = null;
     }
 
     public static function setSushiConnection($connection)
@@ -143,6 +183,7 @@ class Bar extends Model
     {
         static::setSushiConnection(null);
         static::clearBootedModels();
+        static::$testRows = null;
     }
 
     public static function setSushiConnection($connection)


### PR DESCRIPTION
EDIT:

This PR branch has been rebased on the master to make merging easier.
The original commit is here https://github.com/calebporzio/sushi/commit/e6d61c1812353579c2ecd0d4af50f8631827b450

-------------------

Original message

This PR allows to use a set of fake data during tests.

```php
SomeModel::test([
    ['name' => 'foo'],
    ['name' => 'bar']
])
```

It will change the sushi connection to `:memory` and migrate it with the test rows.

### Why use fake data
Caleb already approved the idea of fetching rows via the `getRows()`.
I'm using sushi in app that i'm currently building, and i'm using the `getRows()` (i implemented that locally until this PR (https://github.com/calebporzio/sushi/pull/31) is merged) to read data from an `ini` file. Since the data is not static (defined in the model) i would like to decouple my test from any ini file and use some fake data in my tests.

This can be merged now if caleb is open for adding test `test()` method.
Also if caleb wants to hold off until this https://github.com/calebporzio/sushi/pull/31 is merged, then leave it open and i will update it once https://github.com/calebporzio/sushi/pull/31 is merged.