### PR TITLE
Fix checking and adding primary key

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -83,7 +83,7 @@ trait Sushi
 
         static::resolveConnection()->getSchemaBuilder()->create($tableName, function ($table) use ($firstRow) {
             // Add the "id" column if it doesn't already exist in the rows.
-            if ($this->incrementing && ! in_array($this->primaryKey, array_keys($firstRow))) {
+            if ($this->incrementing && ! array_key_exists($this->primaryKey, $firstRow)) {
                 $table->increments($this->primaryKey);
             }
 

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -88,6 +88,7 @@ class SushiTest extends TestCase
     /** @test */
     function adds_primary_key_if_needed()
     {
+        $this->assertEquals([5,6], FooWithKey::orderBy('id')->pluck('id')->toArray());
         $this->assertEquals(1, Foo::find(1)->getKey());
     }
 
@@ -113,6 +114,16 @@ class Foo extends Model
     {
         static::$sushiConnection = $connection;
     }
+}
+
+class FooWithKey extends Model
+{
+    use \Sushi\Sushi;
+
+    protected $rows = [
+        ['id' => 5, 'foo' => 'bar', 'bob' => 'lob'],
+        ['id' => 6, 'foo' => 'baz', 'bob' => 'law'],
+    ];
 }
 
 class Bar extends Model


### PR DESCRIPTION
EDIT: 
I rebased this PR branch onto the master branch and i noticed that it was fixed but slightly different. But i think doing a `array_key_exists` is easier to read also my PR has tests to verify that adding an auto increment primary key is working as intended.

------------------------

Original message :

Sushi checks if the definition of the primary key exists in the rows, if not it tries to automatically add it.
Checking this condition is wrong, this PR fixes that.

Before the PR if you do something like this

```php
class FooWithKey extends Model
{
    use \Sushi\Sushi;

    protected $rows = [
        ['id' => 5, 'foo' => 'bar', 'bob' => 'lob'],
        ['id' => 6, 'foo' => 'baz', 'bob' => 'law'],
    ];
}
```

You will get an error (defining the primary key column twice) when trying to migrate the table.

`Illuminate\Database\QueryException : SQLSTATE[HY000]: General error: 1 duplicate column name: id (SQL: create table "foo_with_keys" ("id" integer not null primary key autoincrement, "id" integer not null primary key autoincrement, "foo" varchar not null, "bob" varchar not null))`