### PR TITLE
Add support for int, float, and string column types

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -79,9 +79,15 @@ trait Sushi
             }
 
             foreach ($firstRow as $column => $value) {
-                $type = is_numeric($value) ? 'integer' : 'string';
+                if (is_int($value)) {
+                    $type = 'integer';
+                } elseif (is_float($value)) {
+                    $type = 'float';
+                } else {
+                    $type = 'string';
+                }
 
-                if ($column === $this->primaryKey && $type == 'integer') {
+                if ($column === $this->primaryKey && $type === 'integer') {
                     $table->increments($this->primaryKey);
                     continue;
                 }

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -85,6 +85,22 @@ class SushiTest extends TestCase
         $this->assertEquals(1, Foo::find(1)->getKey());
     }
 
+    /** @test */
+    public function it_uses_the_expected_column_types_for_the_schema()
+    {
+        $baz = (new Baz)->first();
+
+        $columns = collect($baz->getConnection()->select("pragma table_info({$baz->getTable()})"));
+
+        $name = $columns->firstWhere('name', 'name');
+        $this->assertEquals('varchar', $name->type);
+
+        $age = $columns->firstWhere('name', 'age');
+        $this->assertEquals('integer', $age->type);
+
+        $price = $columns->firstWhere('name', 'price');
+        $this->assertEquals('float', $price->type);
+    }
 }
 
 class Foo extends Model
@@ -111,4 +127,17 @@ class Foo extends Model
 class Bar extends Model
 {
     use \Sushi\Sushi;
+}
+
+class Baz extends Model
+{
+    use \Sushi\Sushi;
+
+    protected $rows = [
+        [
+            'name' => 'foobar',
+            'age' => 10,
+            'price' => 9.99,
+        ],
+    ];
 }


### PR DESCRIPTION
Adds the ability to determine the correct column type (int, float, string) when the schema is created.
Fixes #30.