### PR TITLE
extract table creation into a function

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -78,6 +78,14 @@ trait Sushi
     public function migrate()
     {
         $rows = $this->getRows();
+
+        $this->createTable($rows);
+
+        static::insert($rows);
+    }
+
+    protected function createTable($rows)
+    {
         $firstRow = $rows[0];
         $tableName = $this->getTable();
 
@@ -98,7 +106,5 @@ trait Sushi
                 $table->{$type}($column);
             }
         });
-
-        static::insert($rows);
     }
 }


### PR DESCRIPTION
This will allow people to overwrite how the database table is created without having to overwrite the whole migrate function.

I myself and https://github.com/calebporzio/sushi/issues/38 ran into this issue and I am sure there will be more people that run into more complex issues with the schemas of their data structures.