### PR TITLE
Support more columns in migrate function.

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -88,8 +88,24 @@ trait Sushi
             }
 
             foreach ($firstRow as $column => $value) {
-                $type = is_numeric($value) ? 'integer' : 'string';
-
+                 
+                switch (true) {
+                    case is_numeric($value):
+                        $type = 'integer';
+                        break;
+                    case is_array($value):
+                        $type = 'longtext';
+                        break;
+                    case is_float($value):
+                        $type = 'float';
+                        break;
+                    case is_string($value):
+                        $type = 'string';
+                        break;
+                    default:
+                        $type = 'string';
+                }
+                
                 if ($column === $this->primaryKey && $type == 'integer') {
                     $table->increments($this->primaryKey);
                     continue;


### PR DESCRIPTION
Simple switch case to check what type of column to create depending on the value given.
The main reason was to support array values.