### PR TITLE
Changed getRows() call to use container so dependencies can be resolved

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -77,7 +77,7 @@ trait Sushi
 
     public function migrate()
     {
-        $rows = $this->getRows();
+        $rows = app()->call([$this, 'getRows']);
         $firstRow = $rows[0];
         $tableName = $this->getTable();
 

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -91,6 +91,19 @@ class SushiTest extends TestCase
         $this->assertEquals(1, Foo::find(1)->getKey());
     }
 
+    /** @test */
+    function get_rows_dependencies_are_resolved_from_container()
+    {
+        app()->bind(ServiceDependency::class, function () {
+            return new ServiceDependency([
+                ['foo' => 'bar']
+            ]);
+        });
+
+        $service = app(ServiceDependency::class);
+
+        $this->assertEquals($service->rows[0], Baz::first());
+    }
 }
 
 class Foo extends Model
@@ -151,7 +164,22 @@ class Bar extends Model
     }
 }
 
+class ServiceDependency
+{
+    public $rows;
+
+    public function __construct(array $rows = [])
+    {
+        $this->rows = $rows;
+    }
+}
+
 class Baz extends Model
 {
     use \Sushi\Sushi;
+
+    public function getRows(ServiceDependency $service)
+    {
+        return $service->rows;
+    }
 }

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -64,6 +64,8 @@ class SushiTest extends TestCase
     /** @test */
     function caches_sqlite_file_if_storage_cache_folder_is_available()
     {
+        File::makeDirectory($this->cachePath);
+
         Foo::count();
 
         $this->assertTrue(file_exists($this->cachePath));

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -36,7 +36,7 @@ class SushiTest extends TestCase
         $this->assertEquals(3, Foo::count());
         $this->assertEquals('bar', Foo::first()->foo);
         $this->assertEquals('lob', Foo::whereBob('lob')->first()->bob);
-        $this->assertEquals(3, Bar::count());
+        $this->assertEquals(2, Bar::count());
         $this->assertEquals('bar', Bar::first()->foo);
         $this->assertEquals('lob', Bar::whereBob('lob')->first()->bob);
     }

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -18,14 +18,14 @@ class SushiTest extends TestCase
 
         Foo::resetStatics();
         Bar::resetStatics();
-        File::cleanDirectory($this->cachePath);
+        File::deleteDirectory($this->cachePath);
     }
 
     public function tearDown(): void
     {
         Foo::resetStatics();
         Bar::resetStatics();
-        File::cleanDirectory($this->cachePath);
+        File::deleteDirectory($this->cachePath);
 
         parent::tearDown();
     }

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -102,7 +102,7 @@ class SushiTest extends TestCase
 
         $service = app(ServiceDependency::class);
 
-        $this->assertEquals($service->rows[0], Baz::first());
+        $this->assertEquals($service->rows[0]['foo'], Baz::first()->foo);
     }
 }
 


### PR DESCRIPTION
This will allow dependencies declared in method signature to be resolved out of the container. I've also fixed and filled the remaining / failing tests.