### PR TITLE
chore: add a "find more" link to Sponsorware/Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Now that we've reached the goal, the package is fully open source.
 
 Enjoy, and thanks for the support! ❤️
 
+Find out more about **Sponsorware** at [github.com/sponsorware/docs](https://github.com/sponsorware/docs) 💰.
+
 ## Install
 ```
 composer require calebporzio/sushi


### PR DESCRIPTION
Added a "_**find more**_" link to your [sponsorware/docs](http://github.com/sponsorware/docs) 💰.