### PR TITLE
Support string IDs

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -109,9 +109,13 @@ trait Sushi
                     default:
                         $type = 'string';
                 }
-
-                if ($column === $this->primaryKey && $type == 'integer') {
-                    $table->increments($this->primaryKey);
+                if ($column === $this->primaryKey) {
+                    if ($type == 'integer') {
+                        $table->increments($this->primaryKey);
+                    }
+                    else {
+                        $table->{$type}($column)->primary($column);
+                    }
                     continue;
                 }
 

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -111,6 +111,13 @@ class SushiTest extends TestCase
     {
         $this->assertEquals(1, Foo::find(1)->getKey());
     }
+
+    /** @test */
+    function supports_non_integer_primary_key()
+    {
+        $this->assertEquals(2, ModelWithStringIds::count());
+        $this->assertEquals('ltr', ModelWithStringIds::find('ltr')->id);
+    }
 }
 
 class Foo extends Model
@@ -161,6 +168,19 @@ class ModelWithCustomSchema extends Model
 
     protected $schema = [
         'float' => 'string',
+    ];
+}
+
+
+class ModelWithStringIds extends Model
+{
+    use \Sushi\Sushi;
+
+    protected $casts = ['id' => 'string'];
+
+    protected $rows = [
+        ['id' => 'ltr', 'title' => 'Left to Right'],
+        ['id' => 'rtl','title' => 'Right to Left'],
     ];
 }
 


### PR DESCRIPTION
Fixes https://github.com/calebporzio/sushi/issues/61

It was assumed the primary key column should always be an integer. This patch supports non integer primary keys. The caveat is that there will not be an auto incrementing column.

Tests are failing on PHP 7.1 because `doctrine/dbal v2.10.1 requires php ^7.2 `