### PR TITLE
Add SushiExists validation rule

### DIFF
--- a/src/Rules/SushiExists.php
+++ b/src/Rules/SushiExists.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Sushi\Rules;
+
+use Sushi\Sushi;
+use Illuminate\Contracts\Validation\Rule;
+
+class SushiExists implements Rule
+{
+    /**
+     * Model instance.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     * @var \Sushi\Sushi
+     */
+    protected $model;
+
+    /**
+     * Column to check if the passed value exists.
+     *
+     * @var string
+     */
+    protected $column;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param string $model
+     * @param string $column
+     * @return void
+     */
+    public function __construct(string $model, string $column = 'id')
+    {
+        $this->model = new $model;
+        $this->column = $column;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return $this->hasSushiTrait() && collect($this->model->getRows())->pluck($this->column)->contains($value);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The selected :attribute is invalid.';
+    }
+
+    /**
+     * Checks if the given model has the sushi trait implemented.
+     *
+     * @return bool
+     */
+    private function hasSushiTrait()
+    {
+        return in_array(Sushi::class, array_keys(class_uses_recursive($this->model)));
+    }
+}

--- a/tests/SushiExistsTest.php
+++ b/tests/SushiExistsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests;
+
+use Sushi\Sushi;
+use Sushi\Rules\SushiExists;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Database\Eloquent\Model;
+
+class SushiExistsTest extends TestCase
+{
+    /** @test */
+    public function it_returns_true_if_the_passed_value_exists_on_the_sushi_model()
+    {
+        $rule = new SushiExists(AwesomeSushiModel::class);
+
+        $this->assertTrue($rule->passes('awesome_id', 1));
+
+        $this->assertFalse($rule->passes('awesome_id', 9999));
+    }
+
+    /** @test */
+    public function it_returns_false_if_the_model_doesnt_have_the_sushi_trait_implemented()
+    {
+        $rule = new SushiExists(BoringNormalModel::class);
+
+        $this->assertFalse($rule->passes('awesome_id', 1));
+    }
+
+    /** @test */
+    public function it_accepts_an_existing_column_value()
+    {
+        $rule = new SushiExists(AwesomeSushiModel::class, 'name');
+
+        $this->assertTrue($rule->passes('awesome_name', 'second_row'));
+    }
+}
+
+class AwesomeSushiModel extends Model
+{
+    use Sushi;
+
+    /**
+     * @return array
+     */
+    protected $rows = [
+        [
+            'id' => 1,
+            'name' => 'first_row',
+            'display_name' => 'The first row',
+        ],
+        [
+            'id' => 2,
+            'name' => 'second_row',
+            'display_name' => 'The second row',
+        ],
+        [
+            'id' => 3,
+            'name' => 'third_row',
+            'display_name' => 'The third row',
+        ],
+    ];
+}
+
+class BoringNormalModel extends Model
+{
+}


### PR DESCRIPTION
Add a SushiExists validation Rule. It is possible to pass the Sushi model and an optional column (default is id), so you can verify on a request that the passed value exists.

Works similar to the Rule::exists() validation.

``` php 
$data = request()->validate([
    'your_attribute' => ['required', new SushiExists(AwesomeSushiModel::class, 'column')],
]);
```