### PR TITLE
Update tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,29 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4]
-        laravel: [5.8.*, 6.*]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+        laravel: [5.8.*, 6.*, 7.*, 8.*]
         os: [ubuntu-latest]
+        include:
+          - laravel: 8.*
+            testbench: 6.*
+          - laravel: 7.*
+            testbench: 5.*
+          - laravel: 6.*
+            testbench: 4.*
+          - laravel: 5.8.*
+            testbench: 3.8.*
         exclude:
+          - laravel: 5.8.*
+            php: 8.0
           - laravel: 6.*
             php: 7.1
+          - laravel: 7.*
+            php: 7.1
+          - laravel: 8.*
+            php: 7.1
+          - laravel: 8.*
+            php: 7.2
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 
@@ -27,7 +44,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extension: mbstring, pdo, pdo_sqlite
@@ -35,7 +52,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-update
+          composer require "illuminate/contracts:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer install --prefer-dist --no-interaction --no-suggest
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,16 @@ jobs:
         include:
           - laravel: 8.*
             testbench: 6.*
+            database: 6.*
           - laravel: 7.*
             testbench: 5.*
+            database: 5.*
           - laravel: 6.*
             testbench: 4.*
+            database: 4.*
           - laravel: 5.8.*
             testbench: 3.8.*
+            database: 3.8.*
         exclude:
           - laravel: 5.8.*
             php: 8.0
@@ -52,7 +56,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/contracts:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "illuminate/contracts:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "orchestra/database:${{ matrix.database }}" --no-interaction --no-update
           composer install --prefer-dist --no-interaction --no-suggest
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,4 +60,4 @@ jobs:
           composer install --prefer-dist --no-interaction --no-suggest
 
       - name: Run tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit --exclude-group skipped

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "doctrine/dbal": "^2.10",
+        "doctrine/dbal": "^2.9",
         "orchestra/database": "3.8.* || 3.9.* || ^4.0 || ^5.0",
         "orchestra/testbench": "3.8.* || 3.9.* || ^4.0 || ^6.0",
         "phpunit/phpunit": "^7.5 || ^8.4 || ^9.0"

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -94,13 +94,19 @@ class SushiTest extends TestCase
         );
     }
 
-    /** @test */
+    /**
+     * @test 
+     * @group skipped
+     * */
     function uses_same_cache_between_requests()
     {
         $this->markTestSkipped("I can't find a good way to test this right now.");
     }
 
-    /** @test */
+    /**
+     * @test 
+     * @group skipped
+     * */
     function use_same_cache_between_requests()
     {
         $this->markTestSkipped("I can't find a good way to test this right now.");


### PR DESCRIPTION
Hey @calebporzio,

I've gone and updated the Github Actions test suite to reflect the support for the Laravel 7.x and 8.x versions as well as the PHP8 that @viezel has contributed recently. 

From what I was able to see when testing this on a private repository, the dependency installation is no longer failing, but the build failure comes down to two test failures:

```php
There were 2 failures:

1) Tests\SushiTest::basic_usage
Failed asserting that 2 matches expected 3.

/home/runner/work/test-sushi-ci/test-sushi-ci/tests/SushiTest.php:39

2) Tests\SushiTest::caches_sqlite_file_if_storage_cache_folder_is_available
Failed asserting that false is true.

/home/runner/work/test-sushi-ci/test-sushi-ci/tests/SushiTest.php:90
```

Hope this helps to get the build back to green soon.

Kind regards,
g