### PR TITLE
Feature: Allow Sushi to work even when there is no data available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Sushi reads the first row in your dataset to work out the scheme of the SQLite t
 
 If you would like Sushi to work even if the dataset is empty, you can define your schema in the optional `protected $schema` array. 
 
+> Note: If you choose to use your own ->getRows() method, the rows will NOT be cached between requests.
+
 ```php
 class Currency extends Model
 {

--- a/README.md
+++ b/README.md
@@ -143,3 +143,28 @@ class Role extends Model
     }
 }
 ```
+### Handling Empty Datasets
+Sushi reads the takes the first row in your dataset to calculate the structure of the SQLite table. If you are using `getRows()` and this returns an empty array (e.g an API returns nothing back) then Sushi would throw an error.
+
+If you would like Sushi to work even if the dataset is empty, you can define an optional `protected $columns` array. To map out the columns Sushi should expect.
+
+> Note: The supported data types are `integer`, `float`, `string`, and `dateTime`. If you enter an unknown data type, it will default to `string`.
+
+```php
+class Currency extends Model
+{
+    use \Sushi\Sushi;
+
+    protected $columns = [
+        'id' => 'integer',
+        'name' => 'string',
+        'symbol' => 'string',
+        'precision' => 'float'
+    ];
+    
+    public function getRows()
+    {
+        return [];
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -146,16 +146,14 @@ class Role extends Model
 ### Handling Empty Datasets
 Sushi reads the takes the first row in your dataset to calculate the structure of the SQLite table. If you are using `getRows()` and this returns an empty array (e.g an API returns nothing back) then Sushi would throw an error.
 
-If you would like Sushi to work even if the dataset is empty, you can define an optional `protected $columns` array. To map out the columns Sushi should expect.
-
-> Note: The supported data types are `integer`, `float`, `string`, and `dateTime`. If you enter an unknown data type, it will default to `string`.
+If you would like Sushi to work even if the dataset is empty, you can define the optional `protected $schema` array. 
 
 ```php
 class Currency extends Model
 {
     use \Sushi\Sushi;
 
-    protected $columns = [
+    protected $schema = [
         'id' => 'integer',
         'name' => 'string',
         'symbol' => 'string',

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ class Role extends Model
 }
 ```
 ### Handling Empty Datasets
-Sushi reads the takes the first row in your dataset to calculate the structure of the SQLite table. If you are using `getRows()` and this returns an empty array (e.g an API returns nothing back) then Sushi would throw an error.
+Sushi reads the first row in your dataset to work out the scheme of the SQLite table. If you are using `getRows()` and this returns an empty array (e.g an API returns nothing back) then Sushi would throw an error.
 
-If you would like Sushi to work even if the dataset is empty, you can define the optional `protected $schema` array. 
+If you would like Sushi to work even if the dataset is empty, you can define your schema in the optional `protected $schema` array. 
 
 ```php
 class Currency extends Model

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,23 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         colors="true"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory suffix="Test.php">tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" forceCoversAnnotation="true" colors="true" beStrictAboutCoversAnnotation="true" beStrictAboutOutputDuringTests="true" beStrictAboutTodoAnnotatedTests="true" verbose="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="default">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/phpunit.xml.bak
+++ b/phpunit.xml.bak
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="true"
+         colors="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -14,7 +14,7 @@ class SushiTest extends TestCase
     {
         parent::setUp();
 
-        config(['sushi.cache-path' => $this->cachePath = __DIR__.'/cache']);
+        config(['sushi.cache-path' => $this->cachePath = __DIR__ . '/cache']);
 
         Foo::resetStatics();
         Bar::resetStatics();
@@ -74,7 +74,7 @@ class SushiTest extends TestCase
     /** @test */
     function uses_in_memory_if_the_cache_directory_is_not_writeable_or_not_found()
     {
-        config(['sushi.cache-path' => $path = __DIR__.'/non-existant-path']);
+        config(['sushi.cache-path' => $path = __DIR__ . '/non-existant-path']);
 
         Foo::count();
 
@@ -111,6 +111,13 @@ class SushiTest extends TestCase
     {
         $this->assertEquals(1, Foo::find(1)->getKey());
     }
+
+
+    /** @test */
+    function it_returns_an_empty_collection()
+    {
+        $this->assertEquals(0, Blank::count());
+    }
 }
 
 class Foo extends Model
@@ -139,7 +146,8 @@ class ModelWithVaryingTypeColumns extends Model
 {
     use \Sushi\Sushi;
 
-    public function getRows() {
+    public function getRows()
+    {
         return [[
             'int' => 123,
             'float' => 123.456,
@@ -203,4 +211,16 @@ class Bar extends Model
 class Baz extends Model
 {
     use \Sushi\Sushi;
+}
+
+class Blank extends Model
+{
+    use \Sushi\Sushi;
+
+    protected $columns = [
+        'id' => 'integer',
+        'name' => 'string'
+    ];
+
+    protected $rows = [];
 }


### PR DESCRIPTION
Hi Caleb 👋

Thank you for Sushi, I really love using it. 

I recently ran into a scenario where I was using `getRows()` to grab data from a third party API, but sometimes the API would return an empty array as its results. Looking into the Sushi trait, it looks like it depends on at least one row of data to be within the array, because it uses that row to work out the column structure. 

To get around this, I wrote two new methods that are invoked on the `migrate()` method. One is `createTable` and the other is `createTableWithNoData`. If there happens to be no rows available, this will look for a new `protected $columns` where you can define your own table structure, all within the model! I've used the same data types that you had in your original `migrate()` command to ensure compatibility.

I also built a simple test for this too, but I'd love to know your thoughts.