### PR TITLE
add composer test script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
     "config": {
         "sort-packages": true
     },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }


### PR DESCRIPTION
With this we can just type `composer test` and run the tests.
It's way cleaner than typing `vendon/bin/phpunit`.