### PR TITLE
Fix sushi is naive with existing cache files

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -4,6 +4,7 @@ namespace Sushi;
 
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Support\Str;
+use PDOException;
 
 trait Sushi
 {
@@ -34,8 +35,13 @@ trait Sushi
         $modelPath = (new \ReflectionClass(static::class))->getFileName();
 
         $states = [
-            'cache-file-found-and-up-to-date' => function () use ($cachePath) {
-                static::setSqliteConnection($cachePath);
+            'cache-file-found-and-up-to-date' => function () use ($cachePath, $instance) {
+                try {
+                    static::setSqliteConnection($cachePath);
+                    $instance->count();
+                } catch (PDOException $e) {
+                    $instance->migrate();
+                }
             },
             'cache-file-not-found-or-stale' => function () use ($cachePath, $modelPath, $instance) {
                 file_put_contents($cachePath, '');

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -116,6 +116,16 @@ class SushiTest extends TestCase
         $this->assertEquals([5,6], ModelWithNonStandardKeys::orderBy('id')->pluck('id')->toArray());
         $this->assertEquals(1, Foo::find(1)->getKey());
     }
+
+    /** @test */
+    function doesnt_assume_an_existing_cache_is_a_valid_cache()
+    {
+        $existingCache = $this->cachePath.'/sushi-tests-foo.sqlite';
+        file_put_contents($existingCache, '');
+        $this->assertTrue(file_exists($existingCache));
+
+        $this->assertEquals(3, Foo::count());
+    }
 }
 
 class Foo extends Model


### PR DESCRIPTION
If you have an existing cache that is invalid (i.e. is empty) Sushi assumes it's the right cache based on its existence and its timestamp being newer than the Class.
This PR checks if we can run the most basic query on our model before finishing the boot and migrates the cache if we can't.