### PR TITLE
Add support for using Sushi models with the `exists` validation rule

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -74,10 +74,14 @@ trait Sushi
 
     protected static function setSqliteConnection($database)
     {
-        static::$sushiConnection = app(ConnectionFactory::class)->make([
+        $config = [
             'driver' => 'sqlite',
             'database' => $database,
-        ]);
+        ];
+
+        static::$sushiConnection = app(ConnectionFactory::class)->make($config);
+
+        app('config')->set('database.connections.sushi', $config);
     }
 
     public function migrate()

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Validator;
 use Orchestra\Testbench\TestCase;
 
 class SushiTest extends TestCase
@@ -99,7 +100,7 @@ class SushiTest extends TestCase
     }
 
     /**
-     * @test 
+     * @test
      * @group skipped
      * */
     function uses_same_cache_between_requests()
@@ -108,7 +109,7 @@ class SushiTest extends TestCase
     }
 
     /**
-     * @test 
+     * @test
      * @group skipped
      * */
     function use_same_cache_between_requests()
@@ -128,6 +129,20 @@ class SushiTest extends TestCase
     function it_returns_an_empty_collection()
     {
         $this->assertEquals(0, Blank::count());
+    }
+
+    /** @test */
+    public function can_use_exists_validation_rule()
+    {
+        ModelWithNonStandardKeys::boot();
+
+        $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:sushi.Tests\ModelWithNonStandardKeys,id'])->passes());
+        $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:sushi.Tests\ModelWithNonStandardKeys'])->passes());
+        $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:sushi.model_with_non_standard_keys'])->passes());
+
+        $this->assertFalse(Validator::make(['id' => 4], ['id' => 'exists:sushi.model_with_non_standard_keys'])->passes());
+        $this->assertFalse(Validator::make(['id' => 6], ['id' => 'exists:sushi.model_with_non_standard_keys,bob'])->passes());
+        $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:sushi.model_with_non_standard_keys'])->passes());
     }
 }
 

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -136,13 +136,17 @@ class SushiTest extends TestCase
     {
         ModelWithNonStandardKeys::boot();
 
-        $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:sushi.Tests\ModelWithNonStandardKeys,id'])->passes());
-        $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:sushi.Tests\ModelWithNonStandardKeys'])->passes());
         $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:sushi.model_with_non_standard_keys'])->passes());
+        $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:sushi.model_with_non_standard_keys'])->passes());
+        (int) explode('.', app()->version())[0] >= 6
+            ? $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:sushi.Tests\ModelWithNonStandardKeys,id'])->passes())
+            : $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:sushi.model_with_non_standard_keys,id'])->passes());
 
         $this->assertFalse(Validator::make(['id' => 4], ['id' => 'exists:sushi.model_with_non_standard_keys'])->passes());
         $this->assertFalse(Validator::make(['id' => 6], ['id' => 'exists:sushi.model_with_non_standard_keys,bob'])->passes());
-        $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:sushi.model_with_non_standard_keys'])->passes());
+        (int) explode('.', app()->version())[0] >= 6
+            ? $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:sushi.Tests\ModelWithNonStandardKeys'])->passes())
+            : $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:sushi.model_with_non_standard_keys'])->passes());
     }
 }
 

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -132,7 +132,7 @@ class SushiTest extends TestCase
     }
 
     /** @test */
-    public function can_use_exists_validation_rule()
+    function can_use_exists_validation_rule()
     {
         ModelWithNonStandardKeys::boot();
 


### PR DESCRIPTION
This PR adds Sushi's generated database connection to the app config `database.connections` array, which makes it possible to use Sushi models with the `exists` database rule. Accomplishes the same thing as #80 but using Laravel's existing validation infrastructure.