### PR TITLE
Actual support for the `exists` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,13 @@ User::with('role')->first();
 > Note: There is one caveat when dealing with Sushi model relationships. The `whereHas` method will NOT work. This is because the two models are spread across two separate databases.
 
 ### Validation
-Since v2.3.0, If you want to use the `exists` validation rule with Sushi, you must prefix the table name with `sushi` so that `exists:countries` becomes `exists:sushi.countries`.
+Since v2.3.0, you may use the `exists` validation rule with Sushi but you must prefix the table name with `sushi.`.
+
+```php
+$request->validate([
+    'role_id' => ['exists:sushi.role,name']
+]);
+```
 
 ### Custom Schema
 If Sushi's schema auto-detection system doesn't meet your specific requirements for the supplied row data, you can customize them with the `$schema` property or the `getSchema()` method.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ User::with('role')->first();
 
 > Note: There is one caveat when dealing with Sushi model relationships. The `whereHas` method will NOT work. This is because the two models are spread across two separate databases.
 
+### Validation
+Since v2.3.0, If you want to use the `exists` validation rule with Sushi, you must prefix the table name with `sushi` so that `exists:countries` becomes `exists:sushi.countries`.
+
 ### Custom Schema
 If Sushi's schema auto-detection system doesn't meet your specific requirements for the supplied row data, you can customize them with the `$schema` property or the `getSchema()` method.
 

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,11 @@
     "config": {
         "sort-packages": true
     },
+    "extra": {
+        "laravel": {
+            "providers": ["Sushi\\SushiServiceProvider"],
+        }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "laravel": {
-            "providers": ["Sushi\\SushiServiceProvider"],
+            "providers": ["Sushi\\SushiServiceProvider"]
         }
     },
     "minimum-stability": "dev",

--- a/src/SushiServiceProvider.php
+++ b/src/SushiServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Sushi;
+
+use Illuminate\Support\ServiceProvider;
+
+class SushiServiceProvider extends ServiceProvider {
+  public function register() {
+        $modelsDirectory = File::isDirectory(app_path('Models')) ? app_path('Models') : app_path();
+        $hasModelsDirectory = $modelsDirectory === app_path('Models');
+
+        $models = File::files($modelsDirectory);
+    
+        collect($models)
+            ->map(function (SplFileInfo $file) use ($hasModelsDirectory) {
+                $modelNamespace = $hasModelsDirectory ? "App\Models\\" : "App\\";
+                $model = $modelNamespace . $file->getFilenameWithoutExtension();
+                $uses = class_uses($model) ?: [];
+
+                return !in_array("Sushi\Sushi", $uses) ? null : $model;
+            })
+            ->filter()
+            ->each(function ($model) {
+                $model::bootSushi();
+            });
+  }
+}


### PR DESCRIPTION
This PR documents support for the `exists` validation rule with Sushi.

But right now, it's only available in the master branch, so a version 2.3.0 should also be released before this PR gets merged.

Also, the current implementation to support the `exists` validation rule was flawed. If the model was not booted before,
It would throw an error saying that the table `sushi.model-name` does not exist (as we set it in the `bootSushi` method).

To fix it, i've added a service provider that boots all sushi models. This means that on top of making the `exists` validation rule work. The QueryBuilder will also work which nice to have even though it's not intented.