### PR TITLE
[Mitigation] configurable chunk size for inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,10 @@ class Currency extends Model
     }
 }
 ```
+
+### Troubleshoot
+
+**ERROR:** `SQLSTATE[HY000]: General error: 1 too many SQL variables`
+
+By default Sushi uses chunks of `100` to insert your data in the SQLite database. In some scenarios this might hit some SQLite limits.
+You can configure the chunk size in the model: `public $sushiInsertChunkSize = 50;`

--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -95,7 +95,7 @@ trait Sushi
             $this->createTableWithNoData($tableName);
         }
 
-        foreach (array_chunk($rows, 100) ?? [] as $inserts) {
+        foreach (array_chunk($rows, $this->getSushiInsertChunkSize()) ?? [] as $inserts) {
             if (!empty($inserts)) {
                 static::insert($inserts);
             }
@@ -176,5 +176,9 @@ trait Sushi
         return (new \ReflectionClass($this))->getProperty('timestamps')->class === static::class
             ? parent::usesTimestamps()
             : false;
+    }
+
+    public function getSushiInsertChunkSize() {
+        return $this->sushiInsertChunkSize ?? 100;
     }
 }


### PR DESCRIPTION
Hello @calebporzio !

I think it's my first contribution here, so first of all thanks for this amazing package. It's simplicity does not equal show the value it provides.

That said, I am working on a project where we use `Sushi` to work with files stored in the filesystem.

This files represent the rows in the model, for each of them we get some properties to save along. The list of files is not static and can grow/shrink over time, and with that grows the number of attributes.

In the other day I tried to access my `sushi` model after creating one more file and got the error: `SQLSTATE[HY000]: General error: 1 too many SQL variables`.

After sometime debugging I found out that reducing the chunk size to `20` instead of the hardcoded `100` solves the issue. In other Sushi models we have 55 is the limit (it depends on the number of attributes that the model have).

I think this error is a little bit difficult to debug with a naked eye, and you could assume that your Sqlite instalation is broken somehow and start upgrading versions and trying other crazy configs. (I am looking in the mirror right now!!!) that's why I also added a troubleshoot section in the readme, because everything could be working great and then break avoc without much warning. (and also because readme is indexed by search engines and anyone searching for that error with sushi keyword might find the answer quickly).

I hope you agree with the proposed changes, let me know if there is something more I can do or if I didn't explain myself well. 

Wish you the best,
Pedro





