### PR TITLE
Avoid error when creating database concurrently

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -2,7 +2,9 @@
 
 namespace Sushi;
 
+use Closure;
 use Illuminate\Database\Connectors\ConnectionFactory;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Str;
 
 trait Sushi
@@ -104,7 +106,7 @@ trait Sushi
 
     public function createTable(string $tableName, $firstRow)
     {
-        static::resolveConnection()->getSchemaBuilder()->create($tableName, function ($table) use ($firstRow) {
+        $this->createTableSafely($tableName, function ($table) use ($firstRow) {
             // Add the "id" column if it doesn't already exist in the rows.
             if ($this->incrementing && ! array_key_exists($this->primaryKey, $firstRow)) {
                 $table->increments($this->primaryKey);
@@ -148,7 +150,7 @@ trait Sushi
 
     public function createTableWithNoData(string $tableName)
     {
-        static::resolveConnection()->getSchemaBuilder()->create($tableName, function ($table) {
+        $this->createTableSafely($tableName, function ($table) {
             $schema = $this->getSchema();
 
             if ($this->incrementing && ! in_array($this->primaryKey, array_keys($schema))) {
@@ -168,6 +170,25 @@ trait Sushi
                 $table->timestamps();
             }
         });
+    }
+
+    protected function createTableSafely(string $tableName, Closure $callback)
+    {
+        /** @var \Illuminate\Database\Schema\SQLiteBuilder $schemaBuilder */
+        $schemaBuilder = static::resolveConnection()->getSchemaBuilder();
+
+        try {
+            $schemaBuilder->create($tableName, $callback);
+        } catch (QueryException $e) {
+            if (Str::contains($e->getMessage(), 'already exists (SQL: create table')) {
+                // This error can happen in rare circumstances due to a race condition.
+                // Concurrent requests may both see the necessary preconditions for
+                // the table creation, but only one can actually succeed.
+                return;
+            }
+
+            throw $e;
+        }
     }
 
     public function usesTimestamps()


### PR DESCRIPTION
After introducing sushi to our project, our monitoring tool reported the following
error (stacktrace shortened for brevity):

```
PDOException: SQLSTATE[HY000]: General error: 1 table "schmelzkurve_scoring_table_results" already exists
#88 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(485): PDOStatement::execute
#87 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(485): Illuminate\Database\Connection::Illuminate\Database\{closure}
#86 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(685): Illuminate\Database\Connection::runQueryCallback
#85 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(652): Illuminate\Database\Connection::run
#84 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(486): Illuminate\Database\Connection::statement
#83 /vendor/laravel/framework/src/Illuminate/Database/Schema/Blueprint.php(109): Illuminate\Database\Schema\Blueprint::build
#82 /vendor/laravel/framework/src/Illuminate/Database/Schema/Builder.php(365): Illuminate\Database\Schema\Builder::build
#81 /vendor/laravel/framework/src/Illuminate/Database/Schema/Builder.php(228): Illuminate\Database\Schema\Builder::create
#80 /vendor/calebporzio/sushi/src/Sushi.php(142): App\Models\SchmelzkurveScoringTableResult::createTable
#79 /vendor/calebporzio/sushi/src/Sushi.php(89): App\Models\SchmelzkurveScoringTableResult::migrate
#78 /vendor/calebporzio/sushi/src/Sushi.php(45): App\Models\SchmelzkurveScoringTableResult::Sushi\{closure}
#77 /vendor/calebporzio/sushi/src/Sushi.php(66): App\Models\SchmelzkurveScoringTableResult::bootSushi
```

This error can happen in rare circumstances due to a race condition.
Concurrent requests may both see the necessary preconditions for
the table creation, but only one can actually succeed.

My initial attempt at resolving this was to look for a method that
creates the table only if it does not exist (`create table if not exists`),
but Laravel exposes no such method. Thus, I think the only viable solution
is to risk it and catch the resulting error.