### PR TITLE
Add caching support for external data files

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -31,20 +31,20 @@ trait Sushi
         $cacheFileName = config('sushi.cache-prefix', 'sushi').'-'.Str::kebab(str_replace('\\', '', static::class)).'.sqlite';
         $cacheDirectory = realpath(config('sushi.cache-path', storage_path('framework/cache')));
         $cachePath = $cacheDirectory.'/'.$cacheFileName;
-        $modelPath = (new \ReflectionClass(static::class))->getFileName();
+        $dataPath = $this->getDataPath();
 
         $states = [
             'cache-file-found-and-up-to-date' => function () use ($cachePath) {
                 static::setSqliteConnection($cachePath);
             },
-            'cache-file-not-found-or-stale' => function () use ($cachePath, $modelPath, $instance) {
+            'cache-file-not-found-or-stale' => function () use ($cachePath, $dataPath, $instance) {
                 file_put_contents($cachePath, '');
 
                 static::setSqliteConnection($cachePath);
 
                 $instance->migrate();
 
-                touch($cachePath, filemtime($modelPath));
+                touch($cachePath, filemtime($dataPath));
             },
             'no-caching-capabilities' => function () use ($instance) {
                 static::setSqliteConnection(':memory:');
@@ -54,11 +54,11 @@ trait Sushi
         ];
 
         switch (true) {
-            case ! property_exists($instance, 'rows'):
+            case ! $this->isCached():
                 $states['no-caching-capabilities']();
                 break;
 
-            case file_exists($cachePath) && filemtime($modelPath) <= filemtime($cachePath):
+            case file_exists($cachePath) && filemtime($dataPath) <= filemtime($cachePath):
                 $states['cache-file-found-and-up-to-date']();
                 break;
 
@@ -176,5 +176,15 @@ trait Sushi
         return (new \ReflectionClass($this))->getProperty('timestamps')->class === static::class
             ? parent::usesTimestamps()
             : false;
+    }
+    
+    protected function getDataPath(): string
+    {
+        return (new \ReflectionClass(static::class))->getFileName();
+    }
+    
+    protected function isCached(): bool
+    {
+        return property_exists(static::class, 'rows');
     }
 }


### PR DESCRIPTION
Currently, Sushi models are only cached when the `$rows` property is used. This is because the alternative is usually to return data from an API using `getRows()`, and caching would mean this data could be out of date.

This PR introduces support to override that behaviour.

First of all, instead of only checking the model file for its last updated timestamp, return a different file path from `getDataPath()`. I frequently like to store Sushi data in config  / CSV files instead and return from `getRows()`, and this feature allows the cache to know when it is out of date.

To allow these external sources to be cached, I've also introduced the `isCached()` method. This allows you to enable the cache at will when using `getRows()`, while preserving original behaviour.

Thanks!