### PR TITLE
Cannot use exists validation without manually specifying connection name & fix multiple model support

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -11,6 +11,8 @@ trait Sushi
 {
     protected static $sushiConnection;
 
+    protected $connection = 'sushi';
+
     public function getRows()
     {
         return $this->rows;

--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -11,8 +11,6 @@ trait Sushi
 {
     protected static $sushiConnection;
 
-    protected $connection = 'sushi';
-
     public function getRows()
     {
         return $this->rows;
@@ -213,5 +211,10 @@ trait Sushi
 
     public function getSushiInsertChunkSize() {
         return $this->sushiInsertChunkSize ?? 100;
+    }
+
+    public function getConnectionName()
+    {
+        return 'sushi';
     }
 }

--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -93,7 +93,7 @@ trait Sushi
 
         static::$sushiConnection = app(ConnectionFactory::class)->make($config);
 
-        app('config')->set('database.connections.sushi', $config);
+        app('config')->set('database.connections.'.static::class, $config);
     }
 
     public function migrate()
@@ -215,6 +215,6 @@ trait Sushi
 
     public function getConnectionName()
     {
-        return 'sushi';
+        return static::class;
     }
 }

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -166,17 +166,17 @@ class SushiTest extends TestCase
     /** @test */
     function can_use_exists_validation_rule()
     {
-        ModelWithNonStandardKeys::boot();
-        ModelWithVaryingTypeColumns::boot();
+        ModelWithNonStandardKeys::all();
+        Foo::all();
 
         $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:'.ModelWithNonStandardKeys::class.'.model_with_non_standard_keys'])->passes());
-        $this->assertTrue(Validator::make(['string' => 'bar'], ['string' => 'exists:'.ModelWithVaryingTypeColumns::class.'.model_with_varying_type_columns'])->passes());
+        $this->assertTrue(Validator::make(['foo' => 'bar'], ['foo' => 'exists:'.Foo::class.'.foos'])->passes());
         (int) explode('.', app()->version())[0] >= 6
             ? $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:'.ModelWithNonStandardKeys::class.',id'])->passes())
             : $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:'.ModelWithNonStandardKeys::class.'.model_with_non_standard_keys,id'])->passes());
 
         $this->assertFalse(Validator::make(['id' => 4], ['id' => 'exists:'.ModelWithNonStandardKeys::class.'.model_with_non_standard_keys'])->passes());
-        $this->assertFalse(Validator::make(['string' => 'baz'], ['string' => 'exists:'.ModelWithVaryingTypeColumns::class.'.model_with_varying_type_columns'])->passes());
+        $this->assertFalse(Validator::make(['foo' => 'bob'], ['foo' => 'exists:'.Foo::class.'.foos'])->passes());
         (int) explode('.', app()->version())[0] >= 6
             ? $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:'.ModelWithNonStandardKeys::class])->passes())
             : $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:'.ModelWithNonStandardKeys::class.'.model_with_non_standard_keys'])->passes());

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -171,13 +171,13 @@ class SushiTest extends TestCase
         $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:sushi.model_with_non_standard_keys'])->passes());
         $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:sushi.model_with_non_standard_keys'])->passes());
         (int) explode('.', app()->version())[0] >= 6
-            ? $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:sushi.Tests\ModelWithNonStandardKeys,id'])->passes())
+            ? $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:Tests\ModelWithNonStandardKeys,id'])->passes())
             : $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:sushi.model_with_non_standard_keys,id'])->passes());
 
         $this->assertFalse(Validator::make(['id' => 4], ['id' => 'exists:sushi.model_with_non_standard_keys'])->passes());
         $this->assertFalse(Validator::make(['id' => 6], ['id' => 'exists:sushi.model_with_non_standard_keys,bob'])->passes());
         (int) explode('.', app()->version())[0] >= 6
-            ? $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:sushi.Tests\ModelWithNonStandardKeys'])->passes())
+            ? $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:Tests\ModelWithNonStandardKeys'])->passes())
             : $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:sushi.model_with_non_standard_keys'])->passes());
     }
 }

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -167,18 +167,19 @@ class SushiTest extends TestCase
     function can_use_exists_validation_rule()
     {
         ModelWithNonStandardKeys::boot();
+        ModelWithVaryingTypeColumns::boot();
 
-        $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:sushi.model_with_non_standard_keys'])->passes());
-        $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:sushi.model_with_non_standard_keys'])->passes());
+        $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:'.ModelWithNonStandardKeys::class.'.model_with_non_standard_keys'])->passes());
+        $this->assertTrue(Validator::make(['string' => 'bar'], ['string' => 'exists:'.ModelWithVaryingTypeColumns::class.'.model_with_varying_type_columns'])->passes());
         (int) explode('.', app()->version())[0] >= 6
-            ? $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:Tests\ModelWithNonStandardKeys,id'])->passes())
-            : $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:sushi.model_with_non_standard_keys,id'])->passes());
+            ? $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:'.ModelWithNonStandardKeys::class.',id'])->passes())
+            : $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:'.ModelWithNonStandardKeys::class.'.model_with_non_standard_keys,id'])->passes());
 
-        $this->assertFalse(Validator::make(['id' => 4], ['id' => 'exists:sushi.model_with_non_standard_keys'])->passes());
-        $this->assertFalse(Validator::make(['id' => 6], ['id' => 'exists:sushi.model_with_non_standard_keys,bob'])->passes());
+        $this->assertFalse(Validator::make(['id' => 4], ['id' => 'exists:'.ModelWithNonStandardKeys::class.'.model_with_non_standard_keys'])->passes());
+        $this->assertFalse(Validator::make(['string' => 'baz'], ['string' => 'exists:'.ModelWithVaryingTypeColumns::class.'.model_with_varying_type_columns'])->passes());
         (int) explode('.', app()->version())[0] >= 6
-            ? $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:Tests\ModelWithNonStandardKeys'])->passes())
-            : $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:sushi.model_with_non_standard_keys'])->passes());
+            ? $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:'.ModelWithNonStandardKeys::class])->passes())
+            : $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:'.ModelWithNonStandardKeys::class.'.model_with_non_standard_keys'])->passes());
     }
 }
 


### PR DESCRIPTION
At the moment, the connection name needs manually specifying when using the `exists` rule.

```php
Rule::exists('sushi.Model');
```

This kinda defeats the object of passing the class as the table name, as it should resolve the connection automatically 😆 

Thankfully, you just need to override the `getConnectionName()` method on the model.

Now, you can use:

```php
Rule::exists('Model');

// or

Rule::exists(Model::class);
```