### PR TITLE
Add docs for using string-based primary keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,26 @@ class Currency extends Model
 }
 ```
 
+### Handling String-based Primary Keys
+Sushi requires you to add two properties to your model, if it uses a string-based primary key - `$incrementing` and `$keyType`:
+
+```php
+class Role extends Model
+{
+    use \Sushi\Sushi;
+    
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $rows = [
+        ['id' => 'admin', 'label' => 'Admin'],
+        ['id' => 'manager', 'label' => 'Manager'],
+        ['id' => 'user', 'label' => 'User'],
+    ];
+}
+```
+
 ### Troubleshoot
 
 **ERROR:** `SQLSTATE[HY000]: General error: 1 too many SQL variables`


### PR DESCRIPTION
You must use both `$incrementing` and `$keyType` when using a string-based primary key with Sushi, else relationship lazy-loading and eager-loading completely break - this does not happen with normal Eloquent models so it's not documented anywhere 🥲 