### PR TITLE
Sushi models can relate to non-sushi models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /.idea/
 /vendor/
+/tests/database/database.sqlite
 .phpunit.result.cache
 composer.lock
+/tests/cache/
+.vscode/settings.json

--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -84,6 +84,15 @@ trait Sushi
         }
     }
 
+    protected function newRelatedInstance($class)
+    {
+        return tap(new $class, function ($instance) {
+            if (!$instance->getConnectionName()) {
+                $instance->setConnection($this->getConnectionResolver()->getDefaultConnection());
+            }
+        });
+    }
+
     protected static function setSqliteConnection($database)
     {
         $config = [

--- a/tests/database/migrations/0000_00_00_000000_create_makis_table.php
+++ b/tests/database/migrations/0000_00_00_000000_create_makis_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMakisTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('makis', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('makis');
+    }
+}


### PR DESCRIPTION
In the current version, you cannot have `belongsTo` relationship from a sushi model to a non-sushi one. The reason behind this is that Laravel assumes the related model is in the same database as the one in which the relation is defined unless you explicitly set the connection name on the related model. With this PR, the default connection is used if the name is not specified. 

The first commit adds the failing test, the second one the fix.

