### PR TITLE
Added `ext-pdo_sqlite` as composer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": "^7.1.3|^8.0",
+        "ext-pdo_sqlite": "*",
         "illuminate/database": "^5.8 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0"
     },


### PR DESCRIPTION
Hi @calebporzio!

Since Sushi depends on `ext-pdo_sqlite` I believe it should be added to composer require section.
This PR aims it, if the `sqlite` extension is not present while installing the package, composer will fail with a warning.

Thanks!