### PR TITLE
Changed the Namespace in the documentation from "Model" to "Models"

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You can even use Laravel's `exists:table,column` database checking request valid
 
 ```php
 $data = request()->validate([
-    'state' => ['required', 'exists:App\Model\State,abbr'],
+    'state' => ['required', 'exists:App\Models\State,abbr'],
 ]);
 ```
 


### PR DESCRIPTION
Hey Caleb,

thanks for you awesome packages. ❤️ 

I changed the namespace in the _Validation_ section from `Model` to `Models`. The default directory name is in plural: https://laravel.com/docs/8.x/structure#the-models-directory

On a fresh Laravel installation you get an error with the namespace `App\Model\`.