### PR TITLE
Add Laravel 9 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,10 +35,16 @@ jobs:
         exclude:
           - laravel: 5.8.*
             php: 8.0
+          - laravel: 5.8.*
+            php: 8.1
           - laravel: 6.*
             php: 7.1
+          - laravel: 6.*
+            php: 8.1
           - laravel: 7.*
             php: 7.1
+          - laravel: 7.*
+            php: 8.1
           - laravel: 8.*
             php: 7.1
           - laravel: 8.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,13 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
-        laravel: [5.8.*, 6.*, 7.*, 8.*]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0, 8.1]
+        laravel: [5.8.*, 6.*, 7.*, 8.*, 9.*]
         os: [ubuntu-latest]
         include:
+          - laravel: 9.*
+            testbench: 7.*
+            database: 7.*
           - laravel: 8.*
             testbench: 6.*
             database: 6.*
@@ -40,6 +43,14 @@ jobs:
             php: 7.1
           - laravel: 8.*
             php: 7.2
+          - laravel: 9.*
+            php: 7.1
+          - laravel: 9.*
+            php: 7.2
+          - laravel: 9.*
+            php: 7.3
+          - laravel: 9.*
+            php: 7.4
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "doctrine/dbal": "^2.9",
-        "orchestra/database": "3.8.* || 3.9.* || ^4.0 || ^5.0 || ^6.0",
+        "orchestra/database": "3.8.* || 3.9.* || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "orchestra/testbench": "3.8.* || 3.9.* || ^4.0 || ^6.0 || ^7.0",
         "phpunit/phpunit": "^7.5 || ^8.4 || ^9.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
     ],
     "require": {
         "php": "^7.1.3|^8.0",
-        "illuminate/database": "^5.8 || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0"
+        "illuminate/database": "^5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
         "doctrine/dbal": "^2.9",
-        "orchestra/database": "3.8.* || 3.9.* || ^4.0 || ^5.0",
-        "orchestra/testbench": "3.8.* || 3.9.* || ^4.0 || ^6.0",
+        "orchestra/database": "3.8.* || 3.9.* || ^4.0 || ^5.0 || ^6.0",
+        "orchestra/testbench": "3.8.* || 3.9.* || ^4.0 || ^6.0 || ^7.0",
         "phpunit/phpunit": "^7.5 || ^8.4 || ^9.0"
     },
     "autoload": {


### PR DESCRIPTION
This PR extends the PHP constraints to support Laravel 9.
The `tests.yml` workflow has been updated, so that PHP 8.1 and Laravel 9 is also tested (and version combinations are excluded that do not work)