### PR TITLE
Async getRows fix

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -84,6 +84,12 @@ trait Sushi
         }
     }
 
+    public static function getSlug()
+    {
+        $slug = Str::slug(str_replace('\\', '-', static::class));
+        return 'sushi-'.$slug;
+    }
+
     protected static function setSqliteConnection($database)
     {
         $config = [
@@ -93,7 +99,7 @@ trait Sushi
 
         static::$sushiConnection = app(ConnectionFactory::class)->make($config);
 
-        app('config')->set('database.connections.'.static::class, $config);
+        app('config')->set('database.connections.'.static::getSlug(), $config);
     }
 
     public function migrate()
@@ -209,12 +215,8 @@ trait Sushi
             : false;
     }
 
-    public function getSushiInsertChunkSize() {
-        return $this->sushiInsertChunkSize ?? 100;
-    }
-
-    public function getConnectionName()
+    public function getSushiInsertChunkSize()
     {
-        return static::class;
+        return $this->sushiInsertChunkSize ?? 100;
     }
 }

--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -83,12 +83,6 @@ trait Sushi
         }
     }
 
-    public static function getSlug()
-    {
-        $slug = Str::slug(str_replace('\\', '-', static::class));
-        return 'sushi-'.$slug;
-    }
-
     protected static function setSqliteConnection($database)
     {
         $config = [
@@ -98,7 +92,7 @@ trait Sushi
 
         static::$sushiConnection = app(ConnectionFactory::class)->make($config);
 
-        app('config')->set('database.connections.'.static::getSlug(), $config);
+        app('config')->set('database.connections.'.static::class, $config);
     }
 
     public function migrate($cachePath = null)
@@ -221,5 +215,10 @@ trait Sushi
     public function getSushiInsertChunkSize()
     {
         return $this->sushiInsertChunkSize ?? 100;
+    }
+
+    public function getConnectionName()
+    {
+        return static::class;
     }
 }

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -169,13 +169,17 @@ class SushiTest extends TestCase
         ModelWithNonStandardKeys::all();
         Foo::all();
 
-        $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:'.ModelWithNonStandardKeys::getSlug().'.model_with_non_standard_keys'])->passes());
-        $this->assertTrue(Validator::make(['foo' => 'bar'], ['foo' => 'exists:'.Foo::getSlug().'.foos'])->passes());
-        $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:'.ModelWithNonStandardKeys::getSlug().'.model_with_non_standard_keys,id'])->passes());
+        $this->assertTrue(Validator::make(['bob' => 'lob'], ['bob' => 'exists:'.ModelWithNonStandardKeys::class.'.model_with_non_standard_keys'])->passes());
+        $this->assertTrue(Validator::make(['foo' => 'bar'], ['foo' => 'exists:'.Foo::class.'.foos'])->passes());
+        (int) explode('.', app()->version())[0] >= 6
+            ? $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:'.ModelWithNonStandardKeys::class.',id'])->passes())
+            : $this->assertTrue(Validator::make(['foo' => 5], ['foo' => 'exists:'.ModelWithNonStandardKeys::class.'.model_with_non_standard_keys,id'])->passes());
 
-        $this->assertFalse(Validator::make(['id' => 4], ['id' => 'exists:'.ModelWithNonStandardKeys::getSlug().'.model_with_non_standard_keys'])->passes());
-        $this->assertFalse(Validator::make(['foo' => 'bob'], ['foo' => 'exists:'.Foo::getSlug().'.foos'])->passes());
-        $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:'.ModelWithNonStandardKeys::getSlug().'.model_with_non_standard_keys'])->passes());
+        $this->assertFalse(Validator::make(['id' => 4], ['id' => 'exists:'.ModelWithNonStandardKeys::class.'.model_with_non_standard_keys'])->passes());
+        $this->assertFalse(Validator::make(['foo' => 'bob'], ['foo' => 'exists:'.Foo::class.'.foos'])->passes());
+        (int) explode('.', app()->version())[0] >= 6
+            ? $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:'.ModelWithNonStandardKeys::class])->passes())
+            : $this->assertFalse(Validator::make(['bob' => 'ble'], ['bob' => 'exists:'.ModelWithNonStandardKeys::class.'.model_with_non_standard_keys'])->passes());
     }
 
     /** @test */
@@ -298,19 +302,4 @@ class Blank extends Model
     ];
 
     protected $rows = [];
-}
-
-class Qux extends Model
-{
-    use \Sushi\Sushi;
-
-    public function getRows()
-    {
-        sleep(1);
-
-        return [
-            ['foo' => 'bar', 'bob' => 'lob'],
-            ['foo' => 'baz', 'bob' => 'law'],
-        ];
-    }
 }

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -4,8 +4,6 @@ namespace Tests;
 
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Validator;
 use Orchestra\Testbench\TestCase;
@@ -181,11 +179,9 @@ class SushiTest extends TestCase
     }
 
     /** @test */
-    public function can_trigger_through_relations()
+    public function it_returns_collection_for_long_standing_rows_calls()
     {
-        $this->expectExceptionMessage("Connection refused");
-
-        Qux::find(1)->quz;
+        $this->markTestSkipped("Need async call to test this");
     }
 }
 
@@ -308,21 +304,13 @@ class Qux extends Model
 {
     use \Sushi\Sushi;
 
-    protected $rows = [
-        ['id' => 1],
-    ];
-
-    public function quz() : HasOne
+    public function getRows()
     {
-        return $this->hasOne(Quz::class);
-    }
-}
+        sleep(1);
 
-
-class Quz extends Model
-{
-    public function qux() : BelongsTo
-    {
-        return $this->belongsTo(Qux::class);
+        return [
+            ['foo' => 'bar', 'bob' => 'lob'],
+            ['foo' => 'baz', 'bob' => 'law'],
+        ];
     }
 }

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -309,20 +309,20 @@ class Qux extends Model
     use \Sushi\Sushi;
 
     protected $rows = [
-        ['id' => 1, 'quz_id' => 1],
+        ['id' => 1],
     ];
 
-    public function quz() : BelongsTo
+    public function quz() : HasOne
     {
-        return $this->belongsTo(Quz::class);
+        return $this->hasOne(Quz::class);
     }
 }
 
 
 class Quz extends Model
 {
-    public function qux() : HasOne
+    public function qux() : BelongsTo
     {
-        return $this->hasOne(Qux::class);
+        return $this->belongsTo(Qux::class);
     }
 }


### PR DESCRIPTION
Currently, per documentation, one can:

> You can optionally opt out of using the protected $rows property, and directly implement your own getRows() method.

> This will allow you to determine the rows for the model at runtime. You can even generate the model's rows from an external source like a third-party API.

If one does so however, this can cause issue when there are multiple requests to the endpoint that generates sqlite files. 

Let's assume that endpoint /foo uses Sushi files, then:
- two requests, are made to the endpoint /foo simultaneously
- first request generates Sushi sqlite file, it's set as empty, triggers getRows() to retrieve data from any source
- second request sees that sqlite file exists and tries to obtain data from it - an `SQLSTATE[HY000]: General error: 1 no such table` will be raised (as sqlite file exists, but has no data in it)
- first request finishes getting rows, puts data into sqlite file and returns correct result

With outlined fix, both requests will succeed (they both won't be cached, and both will write to the same file).

I don't know how to provide a test for the above scenario :) 