### PR TITLE
Sync with Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/support": "^5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
-        "doctrine/dbal": "^2.9",
+        "doctrine/dbal": "^2.9|^3.1.4",
         "orchestra/database": "3.8.* || 3.9.* || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "orchestra/testbench": "3.8.* || 3.9.* || ^4.0 || ^6.0 || ^7.0",
         "phpunit/phpunit": "^7.5 || ^8.4 || ^9.0"


### PR DESCRIPTION
Laravel 9 also offers the option to increase the version of `doctrine/dbal` to 3.x. Just syncing the requirement from Laravel's composer.json to let the project decide which version they want to use.

Version definition Laravel: https://github.com/laravel/framework/blob/9.x/composer.json#L84