### PR TITLE
Add method for $cacheFileName and document config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,38 @@ class Role extends Model
 
 Now, Sushi will only "bust" its internal cache if `roles.csv` changes, rather than looking at the `Role.php` model.
 
+**Note**: By default Sushi will cache the sqlite database file under `storage_path(framework/cache)` with the `kebab-case` name of the class with a `.sqlite` extension and a prefix of `sushi`. To change this behavior you can create a sushi config and/or override the `cacheFileName()` method:
+
+```php
+// config/sushi.php
+<?php
+return [
+    'cache-prefix' => 'my-prefix', // custom
+    'cache-path'   => storage_path('framework/cache'), //default
+];
+```
+
+```php
+class Role extends Model
+{
+    use \Sushi\Sushi;
+
+    protected function sushiShouldCache()
+    {
+        return true;
+    }
+    
+    protected function cacheFileName()
+    {
+        return config('sushi.cache-prefix', 'sushi').'-'.-my-role-database.'.sqlite'; 
+    }
+}
+```
+The above will create the sqlite database file as `storage_path('framework/cache/my-prefix--my-role-database.sqlite')`
+
+**Important**: If you are using more than one sushi model, your cache file names should be unique to ensure that each model gets its own database.
+
+
 ### Handling Empty Datasets
 Sushi reads the first row in your dataset to work out the scheme of the SQLite table. If you are using `getRows()` and this returns an empty array (e.g an API returns nothing back) then Sushi would throw an error.
 

--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -35,12 +35,17 @@ trait Sushi
     {
         return static::$sushiConnection;
     }
+    
+    protected function cacheFileName()
+    {
+        return config('sushi.cache-prefix', 'sushi').'-'.Str::kebab(str_replace('\\', '', static::class)).'.sqlite';
+    }
 
     public static function bootSushi()
     {
         $instance = (new static);
 
-        $cacheFileName = config('sushi.cache-prefix', 'sushi').'-'.Str::kebab(str_replace('\\', '', static::class)).'.sqlite';
+        $cacheFileName = $instance->cacheFileName();
         $cacheDirectory = realpath(config('sushi.cache-path', storage_path('framework/cache')));
         $cachePath = $cacheDirectory.'/'.$cacheFileName;
         $dataPath = $instance->sushiCacheReferencePath();


### PR DESCRIPTION
Currently sushi allows for (undocumented) configuration of the cache path as well as the cache prefix. This PR adds documentation for those options as well as a method for initializing the `$cacheFileName`.

This method will allow for the $cachFileName to be overridden when necessary, for the purposes of easy debugging, cache busting, and file cleanup.

This will not break anything since by default the method simply defines the `$cacheFileName` the same as it was before, as added in #96.

Note: #96 uses `static::class` to ensure cache file names will be unique, to support multiple models using Sushi. This PR documents (in README) the importance of keeping the cache file names unique to each model.

