### PR TITLE
Add after migration callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,27 @@ class Products extends Model
 }
 ```
 
+## Advanced Usage
+When you need more flexibility, you can implement the `runAfterMigrating(BluePrint $table)` method, allowing you to customize the table after it has been created. This might be useful for adding indexes to certain columns. 
+
+```php
+class Products extends Model
+{
+    use \Sushi\Sushi;
+
+    protected $rows = [
+        ['name' => 'Lawn Mower', 'price' => '226.99'],
+        ['name' => 'Leaf Blower', 'price' => '134.99'],
+        ['name' => 'Rake', 'price' => '9.99'],
+    ];
+
+    protected function runAfterMigrating(Blueprint $table)
+    {
+        $table->index('name');
+    }
+}
+```
+
 ## How It Works
 Under the hood, this package creates and caches a SQLite database JUST for this model. It creates a table and populates the rows. If, for whatever reason, it can't cache a .sqlite file, it will default to using an in-memory sqlite database.
 

--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -157,12 +157,13 @@ trait Sushi
                 $table->timestamps();
             }
 
-            $this->runAfterMigrating($table);
+            $this->afterMigrate($table);
         });
     }
 
-    protected function runAfterMigrating(BluePrint $table)
+    protected function afterMigrate(BluePrint $table)
     {
+       //
     }
 
     public function createTableWithNoData(string $tableName)

--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -5,6 +5,7 @@ namespace Sushi;
 use Closure;
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Str;
 
 trait Sushi
@@ -155,7 +156,13 @@ trait Sushi
             if ($this->usesTimestamps() && (! in_array('updated_at', array_keys($firstRow)) || ! in_array('created_at', array_keys($firstRow)))) {
                 $table->timestamps();
             }
+
+            $this->runAfterMigrating($table);
         });
+    }
+
+    protected function runAfterMigrating(BluePrint $table)
+    {
     }
 
     public function createTableWithNoData(string $tableName)

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -262,7 +262,7 @@ class ModelWithAddedTableOperations extends Model
         'string' => 'foo',
     ]];
 
-    protected function runAfterMigrating(Blueprint $table)
+    protected function afterMigrate(Blueprint $table)
     {
         $table->string('columnAdded')->default('columnWasAdded');
     }


### PR DESCRIPTION
Some of the sushi models in our systems contain a significant amount of rows. To speed some queries up, it would be useful to add some indexes to the cache tables. 

This PR allows for adjusting the table after the migration, useful for doing all kind of operations on the table. (Adding indexes, adding/adjusting columns etc). 