### PR TITLE
Replace deprecated phpunit configure

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,9 +11,9 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage>
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
These deprecated `phpunit` elements should be fixing
https://phpunit.readthedocs.io/zh_CN/latest/configuration.html#coverage