### PR TITLE
Support Laravel 10 QueryException message

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -190,7 +190,7 @@ trait Sushi
         try {
             $schemaBuilder->create($tableName, $callback);
         } catch (QueryException $e) {
-            if (Str::contains($e->getMessage(), 'already exists (SQL: create table')) {
+            if (preg_match("/[^#]+already exists[^#]+SQL\: create table/",$e->getMessage()) === 1){
                 // This error can happen in rare circumstances due to a race condition.
                 // Concurrent requests may both see the necessary preconditions for
                 // the table creation, but only one can actually succeed.


### PR DESCRIPTION
Example:
**Before Laravel 10**
`Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1 table "xxx" already exists (SQL: create table "blanks" ("id" integer not null primary key autoincrement))`

**On Laravel 10**
`Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1 table "xxx" already exists (Connection: , SQL: create table "blanks" ("id" integer primary key autoincrement not null))
`