### PR TITLE
Add ability to use complex data types and casts

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -133,11 +133,18 @@ trait Sushi
             $this->createTableWithNoData($tableName);
         }
 
-        foreach (array_chunk($rows, $this->getSushiInsertChunkSize()) ?? [] as $inserts) {
-            if (!empty($inserts)) {
-                static::insert($inserts);
+        if (count($this->casts) === 0) {
+            foreach (array_chunk($rows, $this->getSushiInsertChunkSize()) ?? [] as $inserts) {
+                if (!empty($inserts)) {
+                    static::insert($inserts);
+                }
+            }
+        } else { //casts are necessary, create each model singly so Eloquent can cast attributes as necessary
+            foreach ($rows as $row) {
+                static::create($row);
             }
         }
+
     }
 
     public function createTable(string $tableName, $firstRow)


### PR DESCRIPTION
Currently Sushi inserts rows straight into the database, which does not allow any "complex" data to be saved in rows, not even an array. Think of the use case  
```
[ 
  "county" => "SomeCounty", 
  "postCodes"=>[111,222,333]
]
```

This PR adds the ability to use the model's `$casts`, which allows Eloquent to cast arrays and other data as necessary into/from a string for saving to Sushi's internal SQLite database.