### PR TITLE
[Chore] Migrate phpunit config and remove duplicate test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 composer.lock
 /tests/cache/
 .vscode/settings.json
+.phpunit.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         executionOrder="depends,defects"
-         colors="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory suffix="Test.php">tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <coverage>
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" colors="true" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="default">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/SushiTest.php
+++ b/tests/SushiTest.php
@@ -141,15 +141,6 @@ class SushiTest extends TestCase
         $this->markTestSkipped("I can't find a good way to test this right now.");
     }
 
-    /**
-     * @test
-     * @group skipped
-     * */
-    function use_same_cache_between_requests()
-    {
-        $this->markTestSkipped("I can't find a good way to test this right now.");
-    }
-
     /** @test */
     function adds_primary_key_if_needed()
     {


### PR DESCRIPTION
There were two of the same test. (They were both marked skipped). I removed one of them.

Also phpunit was complaining that the xml config was using a deprecated schema so I updated it with "./vendor/bin/phpunit --migrate-configuration" and added the phpunit result cache to .gitignore 