### PR TITLE
extract cache-file-not-found-or-stale

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -67,13 +67,7 @@ trait Sushi
                 static::setSqliteConnection($cachePath);
             },
             'cache-file-not-found-or-stale' => function () use ($cachePath, $dataPath, $instance) {
-                file_put_contents($cachePath, '');
-
-                static::setSqliteConnection($cachePath);
-
-                $instance->migrate();
-
-                touch($cachePath, filemtime($dataPath));
+                static::cacheFileNotFoundOrStale($cachePath, $dataPath, $instance);
             },
             'no-caching-capabilities' => function () use ($instance) {
                 static::setSqliteConnection(':memory:');
@@ -99,6 +93,17 @@ trait Sushi
                 $states['no-caching-capabilities']();
                 break;
         }
+    }
+
+    protected static function cacheFileNotFoundOrStale($cachePath, $dataPath, $instance)
+    {
+        file_put_contents($cachePath, '');
+
+        static::setSqliteConnection($cachePath);
+
+        $instance->migrate();
+
+        touch($cachePath, filemtime($dataPath));
     }
 
     protected function newRelatedInstance($class)


### PR DESCRIPTION
I have a use case where I need to change the way sushi does file operations on a cache file that is not found or stale.

This PR extracts the logic found in the 'cache-file-not-found-or-stale' state to a protected method.

This does change the logic. It just makes it possible override it without having to override the whole bootSushi() method.