### PR TITLE
validate empty cache file by filesize

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -81,7 +81,7 @@ trait Sushi
                 $states['no-caching-capabilities']();
                 break;
 
-            case file_exists($cachePath) && filemtime($dataPath) <= filemtime($cachePath):
+            case file_exists($cachePath) && filesize($cachePath) > 0 && filemtime($dataPath) <= filemtime($cachePath):
                 $states['cache-file-found-and-up-to-date']();
                 break;
 


### PR DESCRIPTION
When the cache is enabled and the getRows method throws an exception, an empty database file is created. This file passes the exists and mtime checks and results in an error when the file is used the next time. You have do manually delete this file to fix it.