### PR TITLE
Fix: Ensure first element is retrieved from associative array

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -133,7 +133,7 @@ trait Sushi
         $tableName = $this->getTable();
 
         if (count($rows)) {
-            $this->createTable($tableName, $rows[0]);
+            $this->createTable($tableName, array_values($rows)[0]);
         } else {
             $this->createTableWithNoData($tableName);
         }


### PR DESCRIPTION
**What Changed:**
Replaced:

```php
$this->createTable($tableName, $rows[0]);
```

with:

```php
$this->createTable($tableName, array_values($rows)[0]);
```

**Why:**
In cases where `$rows` is not zero-indexed (e.g. after a `filter()` or manually assigned keys), trying to access `$rows[0]` throws:

```
ErrorException: Undefined array key 0
```

**Example:**

```php
$rows = [
    5 => ['id' => 1, 'name' => 'A'],
    6 => ['id' => 2, 'name' => 'B'],
];
```

Accessing `$rows[0]` will trigger the exception above because key `0` doesn't exist.

**Fix:**
`array_values($rows)[0]` reindexes the array numerically, so the first element is always at index `0` regardless of the original keys.

This ensures the code works correctly with any numerically keyed array.
